### PR TITLE
Nissix plugin scope-packages on yoshi-css-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "puppeteer": "^1.1.0",
     "react-test-renderer": "~15.6.0",
     "velocity": "~0.7.0",
-    "yoshi": "^2.1.2"
+    "@wix/yoshi": "^2.1.2"
   },
   "dependencies": {
     "axios": "~0.16.0",
@@ -36,7 +36,7 @@
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-i18next": "~4.8.0",
-    "wix-axios-config": "latest",
+    "@wix/wix-axios-config": "latest",
     "regenerator-runtime": "^0.11.0"
   },
   "yoshi": {

--- a/src/client.js
+++ b/src/client.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import axios from 'axios';
 import {I18nextProvider} from 'react-i18next';
-import {wixAxiosConfig} from 'wix-axios-config';
+import {wixAxiosConfig} from '@wix/wix-axios-config';
 import App from './components/App';
 import i18n from './i18n';
 

--- a/test/mocha-setup.js
+++ b/test/mocha-setup.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {wixAxiosConfig} from 'wix-axios-config';
+import {wixAxiosConfig} from '@wix/wix-axios-config';
 import {baseURL} from './test-common';
 
 wixAxiosConfig(axios, {baseURL});


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 7.001s



Output Log:
Migrating package "yoshi-css-import" in .


## Migration from non scope to @wix/scoped packages
> /tmp/181de612ce413208f29f9bf22c1a2a94

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
src/client.js
test/mocha-setup.js
```

